### PR TITLE
Fixes #21 Pecl requiring PHP 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
   build-essential \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pecl install yaml
+RUN pecl install yaml-1.3.1 <<< ''
 
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
   build-essential \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pecl install yaml-1.3.1 <<< ''
+RUN pecl install yaml-1.3.1
 
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
Verions 2 of Yaml was released, and turned the latest stable version, but this version 2 require only PHP7.

Now it will install Yaml 1.31 version by default.